### PR TITLE
[CAD-5161] Loosen Three.js peer dependency pins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ dist-ssr
 coverage
 
 **/.claude/settings.local.json
+*.tgz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+1.2.1
+---
+* Loosen Three.js peer dependency pins
+
 1.2.0
 ---
 * Add React 19 support

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "threedgizmo",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "threedgizmo",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "devDependencies": {
         "@jest/globals": "^29.7.0",
@@ -15,7 +15,7 @@
         "@types/jest": "^29.5.12",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
-        "@types/three": "0.177.0",
+        "@types/three": "0.183.1",
         "@vitejs/plugin-react": "^4.3.1",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^29.7.0",
@@ -29,10 +29,10 @@
         "vite-plugin-dts": "^4.0.3"
       },
       "peerDependencies": {
-        "@types/three": "0.177.0",
+        "@types/three": ">=0.177.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "three": "0.177.0"
+        "three": ">=0.177.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2150,19 +2150,19 @@
       "dev": true
     },
     "node_modules/@types/three": {
-      "version": "0.177.0",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.177.0.tgz",
-      "integrity": "sha512-/ZAkn4OLUijKQySNci47lFO+4JLE1TihEjsGWPUT+4jWqxtwOPPEwJV1C3k5MEx0mcBPCdkFjzRzDOnHEI1R+A==",
+      "version": "0.183.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.183.1.tgz",
+      "integrity": "sha512-f2Pu5Hrepfgavttdye3PsH5RWyY/AvdZQwIVhrc4uNtvF7nOWJacQKcoVJn0S4f0yYbmAE6AR+ve7xDcuYtMGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
         "@types/stats.js": "*",
-        "@types/webxr": "*",
+        "@types/webxr": ">=0.5.17",
         "@webgpu/types": "*",
         "fflate": "~0.8.2",
-        "meshoptimizer": "~0.18.1"
+        "meshoptimizer": "~1.0.1"
       }
     },
     "node_modules/@types/tough-cookie": {
@@ -6317,10 +6317,11 @@
       "dev": true
     },
     "node_modules/meshoptimizer": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
-      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.0.1.tgz",
+      "integrity": "sha512-Vix+QlA1YYT3FwmBBZ+49cE5y/b+pRrcXKqGpS5ouh33d3lSp2PoTpCw19E0cKDFWalembrHnIaZetf27a+W2g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "threedgizmo",
   "private": false,
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "license": "MIT",
   "scripts": {
@@ -25,10 +25,10 @@
   "module": "dist/three-d-gizmo.es.js",
   "types": "dist/index.d.ts",
   "peerDependencies": {
-    "@types/three": "0.177.0",
+    "@types/three": ">=0.177.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "three": "0.177.0"
+    "three": ">=0.177.0"
   },
   "publishConfig": {
     "access": "public"
@@ -40,7 +40,7 @@
     "@types/jest": "^29.5.12",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "@types/three": "0.177.0",
+    "@types/three": "0.183.1",
     "@vitejs/plugin-react": "^4.3.1",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.7.0",


### PR DESCRIPTION
### Task description

Loosen Three.js peer dependency pins to support Three.js r183 upgrade

### Implementation details

- Change `three` and `@types/three` peer dependencies from exact `0.177.0` to `>=0.177.0` to allow consumers to use newer Three.js versions
- Update `@types/three` dev dependency to `0.183.1` to match the target Three.js version